### PR TITLE
Set Python Version to 3.11 and Use Latest Stable Debian (bookworm = v12 "stable", buster = v10 "oldoldstable")

### DIFF
--- a/config/docker/Dockerfile.web
+++ b/config/docker/Dockerfile.web
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------
 # STAGE 1: Build Python requirements layer
 # ------------------------------------------------------------
-FROM python:3-buster as python-requirements
+FROM python:3.11-bookworm as python-requirements
 
 ARG ENV_NAME=dev
 
@@ -27,7 +27,7 @@ RUN set -ex \
 # ------------------------------------------------------------
 # STAGE 2: Dev layer
 # ------------------------------------------------------------
-FROM python:3-slim-buster as dev
+FROM python:3.11-slim-bookworm as dev
 
 # Set the locale
 # libxml2-dev is needed for uwsgi in the production stage


### PR DESCRIPTION
See: https://github.com/epicserve/django-base-site/issues/456