### PR TITLE
Specified build path in docker-compose.yml for all python images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
     container_name: worker
     image: epicserve/django-base-site:python
     init: true
+    build:
+      context: .
+      dockerfile: config/docker/Dockerfile.web
+      target: dev
 
     command: sh -c "celery -A config worker -l info"
 
@@ -88,6 +92,10 @@ services:
     container_name: docs
     image: epicserve/django-base-site:python
     init: true
+    build:
+      context: .
+      dockerfile: config/docker/Dockerfile.web
+      target: dev
 
     command: sh -c "mkdocs serve -f config/mkdocs.yml --dev-addr 0.0.0.0:4000"
 


### PR DESCRIPTION
Added build section to both `worker` and `docs` to match `web`.

The latest version of docker compose (desktop v4.5+) doesn't seem to pickup on the fact that `{app}:python` was already defined earlier to be in dockerfile `config/docker/Dockerfile.wb`. By specifying it in each section, I'm able to get around the error:

`Error response from daemon: manifest for {app}:python not found: manifest unknown: manifest unknown`