### PR TITLE
Improve prod dockerfile compatibility

### DIFF
--- a/config/docker/Dockerfile.web
+++ b/config/docker/Dockerfile.web
@@ -91,7 +91,8 @@ COPY --chown=app:app . .
 
 USER app
 
-RUN SECRET_KEY=e python manage.py collectstatic --no-input
+# The app user doesn't have permissions to create collected_static on some systems, so we create it here
+RUN mkdir -p /srv/app/collected_static && chown -R app:app /srv/app/collected_static
 
 COPY --from=js_assets --chown=app:app /srv/app/public/static/ ./collected_static
 


### PR DESCRIPTION
The `app` user doesn't have permission to create `/srv/app/collected_static` on some systems. We should instead create and permission the directory as `root` before we collect static as the app user. I ran into this error when deploying with fly.io

Error:
```
 > [prod 4/5] RUN SECRET_KEY=e python manage.py collectstatic --no-input:
1.967 Traceback (most recent call last):
1.967   File "/srv/app/manage.py", line 23, in <module>
1.967     main()
1.967   File "/srv/app/manage.py", line 19, in main
1.967     execute_from_command_line(sys.argv)
1.967   File "/opt/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
1.967     utility.execute()
1.967   File "/opt/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
1.967     self.fetch_command(subcommand).run_from_argv(self.argv)
1.968   File "/opt/venv/lib/python3.12/site-packages/django/core/management/base.py", line 413, in run_from_argv
1.968     self.execute(*args, **cmd_options)
1.968   File "/opt/venv/lib/python3.12/site-packages/django/core/management/base.py", line 459, in execute
1.968     output = self.handle(*args, **options)
1.968              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1.968   File "/opt/venv/lib/python3.12/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 209, in handle
1.968     collected = self.collect()
1.968                 ^^^^^^^^^^^^^^
1.968   File "/opt/venv/lib/python3.12/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 135, in collect
1.968     handler(path, prefixed_path, storage)
1.968   File "/opt/venv/lib/python3.12/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 378, in copy_file
1.969     self.storage.save(prefixed_path, source_file)
1.969   File "/opt/venv/lib/python3.12/site-packages/django/core/files/storage/base.py", line 49, in save
1.969     name = self._save(name, content)
1.969            ^^^^^^^^^^^^^^^^^^^^^^^^^
1.969   File "/opt/venv/lib/python3.12/site-packages/django/core/files/storage/filesystem.py", line 100, in _save
1.969     os.makedirs(directory, exist_ok=True)
1.969   File "<frozen os>", line 215, in makedirs
1.969   File "<frozen os>", line 215, in makedirs
1.969   File "<frozen os>", line 225, in makedirs
1.969 PermissionError: [Errno 13] Permission denied: '/srv/app/collected_static'
------
Error: failed to fetch an image or build from source: error building: failed to solve: process "/bin/sh -c SECRET_KEY=e python manage.py collectstatic --no-input" did not complete successfully: exit code: 1
```
